### PR TITLE
Add options to use with pdftotext: encoding and mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,8 @@ var pdf_extract = require('pdf-extract');
 var absolute_path_to_pdf = '~/Downloads/electronic.pdf'
 var options = {
   type: 'text',  // extract the actual text in the pdf file
-  enc: 'UTF-8'   // optional, encoding to use for the text output
+  enc: 'UTF-8',  // optional, encoding to use for the text output
+  mode: 'layout' // optional, mode to use when reading the pdf 
 }
 var processor = pdf_extract(absolute_path_to_pdf, options, function(err) {
   if (err) {
@@ -200,7 +201,8 @@ When the system performs extracts text from a multi-page pdf, it first splits th
 ``` javascript
 var options = {
   type: 'ocr' // (required), perform ocr to get the text within the scanned image
-  enc: 'UTF-8' // optional, only applies to 'text' type 
+  enc: 'UTF-8' // optional, only applies to 'text' type
+  mode: 'layout' // optional, only applies to 'text' type. Available modes are 'layout', 'simple', 'table' or 'lineprinter'. Default is 'layout'
   clean: false // keep the single page pdfs created during the ocr process
   ocr_flags: [
     '-psm 1',       // automatically detect page orientation

--- a/README.md
+++ b/README.md
@@ -174,7 +174,8 @@ var inspect = require('eyes').inspector({maxLength:20000});
 var pdf_extract = require('pdf-extract');
 var absolute_path_to_pdf = '~/Downloads/electronic.pdf'
 var options = {
-  type: 'text'  // extract the actual text in the pdf file
+  type: 'text',  // extract the actual text in the pdf file
+  enc: 'UTF-8'   // optional, encoding to use for the text output
 }
 var processor = pdf_extract(absolute_path_to_pdf, options, function(err) {
   if (err) {
@@ -199,6 +200,7 @@ When the system performs extracts text from a multi-page pdf, it first splits th
 ``` javascript
 var options = {
   type: 'ocr' // (required), perform ocr to get the text within the scanned image
+  enc: 'UTF-8' // optional, only applies to 'text' type 
   clean: false // keep the single page pdfs created during the ocr process
   ocr_flags: [
     '-psm 1',       // automatically detect page orientation

--- a/lib/searchable.js
+++ b/lib/searchable.js
@@ -23,7 +23,7 @@ var rimraf = require('rimraf');
  */
 module.exports = function(pdf_path, options, callback) {
   if(options===undefined)options={};
-  if(options.layout===undefined)options.layout=true;
+  if(options.mode===undefined)options.mode='layout';
   confirm_file_exists(pdf_path, function (err) {
     if (err) { return callback(err); }
     var child = spawn('pdftotext', (spawnOptions(options)).concat([pdf_path, '-']));
@@ -47,9 +47,7 @@ module.exports = function(pdf_path, options, callback) {
 
 function spawnOptions(options) {
   var result = [];
-  if (options.layout) {
-    result.push('-layout');
-  }
+  result.push('-' + options.mode);
   if (options.enc) {
     result.push('-enc');
     result.push(options.enc);

--- a/lib/searchable.js
+++ b/lib/searchable.js
@@ -26,7 +26,7 @@ module.exports = function(pdf_path, options, callback) {
   if(options.layout===undefined)options.layout=true;
   confirm_file_exists(pdf_path, function (err) {
     if (err) { return callback(err); }
-    var child = spawn('pdftotext', (options.layout ? ['-layout'] : []).concat([pdf_path, '-']));
+    var child = spawn('pdftotext', (spawnOptions(options)).concat([pdf_path, '-']));
     var stdout = child.stdout;
     var stderr = child.stderr;
     var output = '';
@@ -45,6 +45,17 @@ module.exports = function(pdf_path, options, callback) {
   });
 }
 
+function spawnOptions(options) {
+  var result = [];
+  if (options.layout) {
+    result.push('-layout');
+  }
+  if (options.enc) {
+    result.push('-enc');
+    result.push(options.enc);
+  }
+  return result;
+}
 
 /**
  * Non-recursive find of all the files in a given directory that end with *.pdf


### PR DESCRIPTION
I was having someissues with special characters like "ü", after some research, the problem seems to be solved specifying the encoding on pdftotext, since there was no way to do it (AFAICS), I prepared this pull request.

Edit: I was also having issues with tables, setting the mode to -table solved my problem. I added an option to specify the mode as well.

See https://www.xpdfreader.com/pdftotext-man.html