### PR TITLE
Add pages_from pages_to options to raw parser

### DIFF
--- a/lib/raw.js
+++ b/lib/raw.js
@@ -74,6 +74,12 @@ Raw.prototype.process = function(pdf_path, options) {
           self.emit('error', { error: err, pdf_path: pdf_path});
           return;
         }
+        if (Number.isInteger(options.pages_to)) {
+            pdf_files = pdf_files.slice(0, options.pages_to);
+        }
+        if (Number.isInteger(options.pages_from)) {
+            pdf_files = pdf_files.slice(options.pages_from);
+        }
         var index = 0;
         var num_pages = pdf_files.length
         var single_page_pdf_file_paths = [];


### PR DESCRIPTION
This allows to limit the number of pages parsed for some scenarios where only a few pages are really necessary.